### PR TITLE
Add isReadOnly field to Calendar

### DIFF
--- a/lib/src/model/calendar.dart
+++ b/lib/src/model/calendar.dart
@@ -5,14 +5,16 @@ class Calendar {
   String? name;
   String? accountName;
   String? ownerName;
+  bool? isReadOnly;
 
-  Calendar({required this.id, this.name, this.accountName, this.ownerName});
+  Calendar({required this.id, this.name, this.accountName, this.ownerName, this.isReadOnly});
 
   Calendar.fromJson(Map<String, dynamic> data) {
     this.id = data["id"];
     this.name = data["name"];
     this.accountName = data["accountName"];
     this.ownerName = data["ownerName"];
+    this.isReadOnly = data["isReadOnly"];
   }
 
   Map<String, dynamic> toJson() {
@@ -21,6 +23,7 @@ class Calendar {
     data["name"] = this.name;
     data["accountName"] = this.accountName;
     data["ownerName"] = this.ownerName;
+    data["isReadOnly"] = this.isReadOnly;
     return data;
   }
 }


### PR DESCRIPTION
This is the fix for adding `isReadOnly` to `Calendar` as I described in #16 