### PR TITLE
remove registrar: Unresolved reference: Registrar

### DIFF
--- a/android/src/main/java/com/fantastic/manage_calendar_events/ManageCalendarEventsPlugin.java
+++ b/android/src/main/java/com/fantastic/manage_calendar_events/ManageCalendarEventsPlugin.java
@@ -22,7 +22,6 @@ import io.flutter.plugin.common.MethodCall;
 import io.flutter.plugin.common.MethodChannel;
 import io.flutter.plugin.common.MethodChannel.MethodCallHandler;
 import io.flutter.plugin.common.MethodChannel.Result;
-import io.flutter.plugin.common.PluginRegistry.Registrar;
 
 /**
  * ManageCalendarEventsPlugin

--- a/android/src/main/java/com/fantastic/manage_calendar_events/ManageCalendarEventsPlugin.java
+++ b/android/src/main/java/com/fantastic/manage_calendar_events/ManageCalendarEventsPlugin.java
@@ -62,16 +62,6 @@ public class ManageCalendarEventsPlugin implements FlutterPlugin, ActivityAware,
         methodChannel.setMethodCallHandler(null);
     }
 
-    /**
-     * Plugin registration.
-     */
-    public static void registerWith(Registrar registrar) {
-        Context context = registrar.context();
-        Activity activity = registrar.activity();
-        setup(new ManageCalendarEventsPlugin(), registrar.messenger(), activity, context);
-    }
-
-
     @Override
     public void onAttachedToActivity(@NonNull ActivityPluginBinding binding) {
         Log.d("DART/NATIVE", "onAttachedToActivity");


### PR DESCRIPTION
Starting with Flutter 3.28, importing Registrar will result in an unresolved reference error:

```
Unresolved reference: Registrar


import io.flutter.plugin.common.PluginRegistry.Registrar;
```
To address this, I removed the Registrar import. The replacement, FlutterPlugin, is already included, which should resolve the issue.

For more details, please refer to the official documentation on this breaking change: [Plugin API Migration](https://docs.flutter.dev/release/breaking-changes/plugin-api-migration).